### PR TITLE
When in mobile mode, allow switching through chord inversions with a second button in the top corner

### DIFF
--- a/src/components/tab/chordtext.tsx
+++ b/src/components/tab/chordtext.tsx
@@ -18,10 +18,14 @@ export default function ChordText({
   transposedChord,
   fontSize,
   inversion,
+  isMobile,
+  onCycle,
 }: {
   transposedChord: TransposedChord;
   fontSize: number;
   inversion: number;
+  isMobile: boolean;
+  onCycle?: () => void;
 }) {
   const { guitarChords: chordsDB } = useConfigStore();
 
@@ -90,11 +94,27 @@ export default function ChordText({
               }}
               className="pointer-events-none bg-white border-black border-2 rounded"
             >
-              <div className="text-center chord text-black">
-                <span className="font-bold mr-2">{`${transposedChord.key}${transposedChord.simpleSuffix}`}</span>
-                <span>
-                  ({(inversion % (positions?.length ?? 0)) + 1}/{positions?.length})
-                </span>
+              <div className="flex items-center justify-between">
+                <div className="text-center chord text-black">
+                  <span className="font-bold mr-2">{`${transposedChord.key}${transposedChord.simpleSuffix}`}</span>
+                  <span>
+                    ({(inversion % (positions?.length ?? 0)) + 1}/{positions?.length})
+                  </span>
+                </div>
+                {isMobile && onCycle && (positions?.length ?? 0) > 1 ? (
+                  <button
+                    type="button"
+                    aria-label="Cycle to the next chord inversion"
+                    className="pointer-events-auto rounded-full bg-gray-200 text-black hover:bg-gray-300 px-2 py-1 text-sm font-bold leading-none select-none"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onCycle();
+                    }}
+                  >
+                    ⟳
+                  </button>
+                ) : null}
               </div>
               <Chord chord={chordObj} instrument={instrument} lite={true} />
             </div>,

--- a/src/components/tab/chordtext.tsx
+++ b/src/components/tab/chordtext.tsx
@@ -41,6 +41,25 @@ export default function ChordText({
   const inputRef = useRef<HTMLElement>(null);
   const [showPopup, setShowPopup] = useState(false);
   const [popupStyle, setPopupStyle] = useState<{ top: number; left: number } | null>(null);
+  const closeTimer = useRef<number | null>(null);
+
+  const openPopup = () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    setShowPopup(true);
+  };
+
+  const closePopup = () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    // The cycle button lives in a portal OUTSIDE the chord span, so moving the
+    // pointer/tap from the chord to the button crosses the span's boundary and
+    // fires onMouseLeave/onBlur. Delay the close so the button's own
+    // enter/click handlers can cancel it — otherwise the popup vanishes the
+    // moment you try to cycle inversions.
+    closeTimer.current = window.setTimeout(() => setShowPopup(false), 150);
+  };
 
   useEffect(() => {
     if (!showPopup) return;
@@ -66,10 +85,10 @@ export default function ChordText({
         ref={inputRef}
         tabIndex={0}
         onTouchStart={() => inputRef.current?.focus()}
-        onMouseEnter={() => setShowPopup(true)}
-        onMouseLeave={() => setShowPopup(false)}
-        onFocus={() => setShowPopup(true)}
-        onBlur={() => setShowPopup(false)}
+        onMouseEnter={openPopup}
+        onMouseLeave={closePopup}
+        onFocus={openPopup}
+        onBlur={closePopup}
       >
         <span
           className={`bg-gray-200 dark:bg-gray-600 font-bold rounded-md chord z-10 relative ${
@@ -92,31 +111,35 @@ export default function ChordText({
                 transform: "translateX(-50%)",
                 zIndex: 9999,
               }}
-              className="pointer-events-none bg-white border-black border-2 rounded"
+              className="pointer-events-none relative bg-white border-black border-2 rounded"
             >
-              <div className="flex items-center justify-between">
-                <div className="text-center chord text-black">
-                  <span className="font-bold mr-2">{`${transposedChord.key}${transposedChord.simpleSuffix}`}</span>
-                  <span>
-                    ({(inversion % (positions?.length ?? 0)) + 1}/{positions?.length})
-                  </span>
-                </div>
-                {isMobile && onCycle && (positions?.length ?? 0) > 1 ? (
-                  <button
-                    type="button"
-                    aria-label="Cycle to the next chord inversion"
-                    className="pointer-events-auto rounded-full bg-gray-200 text-black hover:bg-gray-300 px-2 py-1 text-sm font-bold leading-none select-none"
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onCycle();
-                    }}
-                  >
-                    ⟳
-                  </button>
-                ) : null}
+              <div className="text-center chord text-black px-8 pt-1 pb-0.5">
+                <span className="font-bold mr-2">{`${transposedChord.key}${transposedChord.simpleSuffix}`}</span>
+                <span>
+                  ({(inversion % (positions?.length ?? 0)) + 1}/{positions?.length})
+                </span>
               </div>
               <Chord chord={chordObj} instrument={instrument} lite={true} />
+              {isMobile && onCycle && (positions?.length ?? 0) > 1 ? (
+                <button
+                  type="button"
+                  aria-label="Cycle to the next chord inversion"
+                  className="pointer-events-auto absolute top-1.5 right-1.5 rounded-full bg-gray-200 text-black hover:bg-gray-300 px-2 py-1 text-sm font-bold leading-none select-none"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onMouseEnter={openPopup}
+                  onMouseLeave={closePopup}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    // Tapping the button can blur the chord span (and thus
+                    // close the popup); refocus it so the popup stays open
+                    // across the inversion switch.
+                    inputRef.current?.focus();
+                    onCycle();
+                  }}
+                >
+                  ⟳
+                </button>
+              ) : null}
             </div>,
             // portal root must exist in _document.tsx
             (typeof document !== "undefined" && document.getElementById("portal-root")) || document.body

--- a/src/hooks/useFormattedTab.tsx
+++ b/src/hooks/useFormattedTab.tsx
@@ -26,14 +26,20 @@ export default function useFormattedTab(plainTab: string, transposition: number,
     });
   }, [chords, transposition]);
 
+  const incrementInversion = (chord: string) => {
+    setInversions((old) => {
+      let value = { ...old };
+      value[chord] += 1;
+      return value;
+    });
+  };
+
+  // Desktop: hovering shows the diagram and clicking the chord cycles the
+  // inversion. Mobile has no hover, so tapping must only reveal the diagram;
+  // cycling there happens via the popup's cycle button (see ChordText), which
+  // calls incrementInversion directly.
   const cycleInversion = (chord: string) => {
-    if (!isMobile) {
-      setInversions((old) => {
-        let value = { ...old };
-        value[chord] += 1;
-        return value;
-      });
-    }
+    if (!isMobile) incrementInversion(chord);
   };
 
   let chordElements: Map<string, JSX.Element> = new Map();
@@ -42,7 +48,13 @@ export default function useFormattedTab(plainTab: string, transposition: number,
     if (transposedChords[chord]) {
       chordElements.set(
         chord,
-        <ChordText transposedChord={transposedChords[chord]} fontSize={fontSize} inversion={inversions[chord] ?? 0} />
+        <ChordText
+          transposedChord={transposedChords[chord]}
+          fontSize={fontSize}
+          inversion={inversions[chord] ?? 0}
+          isMobile={isMobile}
+          onCycle={() => incrementInversion(chord)}
+        />
       );
     }
   }


### PR DESCRIPTION
Closes #166

## Problem
On mobile there is no hover mechanism, so tapping a chord only reveals the diagram (via focus) and there was no way to cycle through alternate chord inversions — the existing inline click would immediately toggle, and the popup was pointer-events-none so it couldn't be tapped.

## Fix
- Chord popup now shows a small cycle button (⟳) in the top-right corner, but only on mobile.
- Tapping it steps to the next chord inversion while keeping the diagram open.
- Desktop keeps the existing behavior: hover shows the diagram, clicking the chord cycles inversions.

## Notes
No staging env exists for this repo (only a production ssh deploy target), so the PR is the deliverable — no live-testable artifact.