### PR TITLE
Lazy-load playlist tracks on the homepage

### DIFF
--- a/src/components/home/playlistpanel.tsx
+++ b/src/components/home/playlistpanel.tsx
@@ -1,56 +1,94 @@
+import { Track } from "@/models/models";
 import { Playlist } from "@/types/spotify";
 import { trpc } from "@/utils/trpc";
 import Link from "next/link";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { stripRemasterAnnotations } from "src/utils/title";
 import BasePanel from "../shared/basepanel";
 import PlainButton from "../shared/plainbutton";
 import PanelMenu from "./panelmenu";
 
-export default function PlaylistPanel({ playlist }: { playlist: Playlist }) {
-  const [hovering, setHovering] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
+const TRACKS_PAGE_SIZE = 100;
+const LONG_PRESS_MS = 600;
 
-  const divRef = useRef<HTMLDivElement>(null);
+export default function PlaylistPanel({ playlist }: { playlist: Playlist }) {
+  const [isOpen, setIsOpen] = useState(false);
 
   const [isImportOpen, setIsImportOpen] = useState(false);
   const getPlaylist = trpc.spotify.getPlaylistLazy.useMutation();
+
+  const playlistId = playlist.uri.split(":").at(-1) ?? "";
+  const { data, isLoading, isFetching, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    trpc.spotify.getPlaylistTracks.useInfiniteQuery(
+      { playlistId, pageSize: TRACKS_PAGE_SIZE },
+      {
+        enabled: isOpen,
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      }
+    );
+
+  const tracks = data?.pages.flatMap((p) => p.items) ?? [];
+  const total = data?.pages[0]?.total ?? playlist.tracks.total;
+
+  const [loadingAll, setLoadingAll] = useState(false);
   const [pulling, setPulling] = useState<string | null>(null);
-  // const _d = trpc.spotify.getPlaylist.useInfiniteQuery(
-  //   { playlistId: playlist.playlistId ?? "", save: true },
-  //   {
-  //     enabled: isImportOpen,
-  //     getNextPageParam: (lastPage) => lastPage.nextCursor,
-  //     initialCursor: 0,
-  //   }
-  // );
+  const hasNextPageRef = useRef(hasNextPage);
+  const pullTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pullFired = useRef(false);
+
+  useEffect(() => {
+    hasNextPageRef.current = hasNextPage;
+  }, [hasNextPage]);
 
   const importPlaylist = async () => {
-    await getPlaylist.mutateAsync({
-      playlistId: playlist.id,
-    });
-
+    await getPlaylist.mutateAsync({ playlistId });
     setIsImportOpen(true);
   };
 
-  const scrapeAll = async () => {
-    if (!data) return;
-
-    for (let track of data.tracks) {
-      setPulling(track.name);
-      await fetch(`/track/${track.trackId.split(":").at(-1)}`).catch(() => console.log("Couldn't find track", track));
-      await new Promise((r) => setTimeout(r, 2000));
+  // Load every remaining page, returning the flattened list.
+  const loadAll = async (): Promise<Track[]> => {
+    setLoadingAll(true);
+    try {
+      let guard = 0;
+      let lastRes;
+      while (hasNextPageRef.current && guard < 10000) {
+        guard++;
+        lastRes = await fetchNextPage();
+        hasNextPageRef.current = lastRes.hasNextPage;
+      }
+      if (!lastRes || !lastRes.data) return tracks;
+      return lastRes.data.pages.flatMap((p: any) => p.items);
+    } finally {
+      setLoadingAll(false);
     }
-
-    setPulling(null);
   };
 
-  const { data, isLoading } = trpc.spotify.getPlaylist.useQuery(
-    { playlistId: playlist.uri.split(":").at(-1) ?? "", save: false },
-    {
-      enabled: isOpen,
+  const onLoadMorePress = () => {
+    if (pullTimer.current) clearTimeout(pullTimer.current);
+    pullFired.current = false;
+    pullTimer.current = setTimeout(() => {
+      pullFired.current = true;
+      loadAll();
+    }, LONG_PRESS_MS);
+  };
+  const onLoadMoreRelease = async () => {
+    if (pullTimer.current) {
+      clearTimeout(pullTimer.current);
+      pullTimer.current = null;
+      if (!pullFired.current) fetchNextPage();
     }
-  );
+  };
+
+  const scrapeAll = async () => {
+    if (!total) return;
+    const all = await loadAll();
+    for (let track of all) {
+      setPulling(track.name);
+      await fetch(`/track/${track.trackId}`).catch(() => console.log("Couldn't find track", track));
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    setPulling(null);
+  };
 
   return (
     <>
@@ -69,7 +107,7 @@ export default function PlaylistPanel({ playlist }: { playlist: Playlist }) {
         }
         footer={
           <>
-            <div className="ml-2">{playlist.tracks.total} items</div>
+            <div className="ml-2">{total} items</div>
             <PanelMenu
               menuItems={[
                 {
@@ -89,11 +127,11 @@ export default function PlaylistPanel({ playlist }: { playlist: Playlist }) {
           </>
         }
         id={`playlist-${playlist.id}`}
-        isLoading={isLoading}
+        isLoading={isLoading || loadingAll}
       >
-        {data?.tracks.map((t, j) => (
+        {tracks.map((t, j) => (
           <PlainButton
-            href={`/track/${t.trackId?.split(":").at(-1)}`}
+            href={`/track/${t.trackId}`}
             key={j}
             className="w-full text-black dark:text-gray-200 no-underline hover:no-underline active:text-black dark:active:text-white"
             prefetch={false}
@@ -101,6 +139,27 @@ export default function PlaylistPanel({ playlist }: { playlist: Playlist }) {
             <span className="font-bold text-sm">{stripRemasterAnnotations(t.name)}</span> - {t.artists.join(", ")}
           </PlainButton>
         ))}
+        {hasNextPage && !loadingAll && (
+          <PlainButton
+            className="w-full text-black dark:text-gray-200 no-underline hover:no-underline active:text-black dark:active:text-white flex justify-center items-center h-12"
+            onPointerDown={onLoadMorePress}
+            onPointerUp={onLoadMoreRelease}
+            onPointerLeave={() => {
+              if (pullTimer.current) {
+                clearTimeout(pullTimer.current);
+                pullTimer.current = null;
+              }
+            }}
+            isLoading={isFetching || isFetchingNextPage}
+          >
+            {isFetching || isFetchingNextPage ? "Loading…" : "Load more"}
+          </PlainButton>
+        )}
+        {pulling && (
+          <div className="flex justify-center items-center h-12 text-sm text-gray-500 dark:text-gray-400">
+            Pulling {pulling}…
+          </div>
+        )}
       </BasePanel>
     </>
   );

--- a/src/components/shared/plainbutton.tsx
+++ b/src/components/shared/plainbutton.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { MouseEventHandler, ReactNode } from "react";
+import { MouseEventHandler, PointerEventHandler, ReactNode } from "react";
 import LoadingSpinner from "../loadingspinner";
 
 export default function PlainButton({
@@ -13,6 +13,9 @@ export default function PlainButton({
   prefetch,
   isLoading,
   onContextMenu,
+  onPointerDown,
+  onPointerUp,
+  onPointerLeave,
 }: {
   children: ReactNode;
   onClick?: MouseEventHandler<HTMLElement>;
@@ -24,6 +27,9 @@ export default function PlainButton({
   prefetch?: boolean;
   isLoading?: boolean;
   onContextMenu?: MouseEventHandler<HTMLElement>;
+  onPointerDown?: PointerEventHandler<HTMLElement>;
+  onPointerUp?: PointerEventHandler<HTMLElement>;
+  onPointerLeave?: PointerEventHandler<HTMLElement>;
 }) {
   const clsname =
     "relative border-gray-200 bg-white dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-700 border rounded-xl transition duration-75 dark:border-gray-600 " +
@@ -36,7 +42,15 @@ export default function PlainButton({
       {children}
     </Link>
   ) : (
-    <button className={clsname} onContextMenu={onContextMenu} onClick={disabled ? undefined : onClick} title={title}>
+    <button
+      className={clsname}
+      onContextMenu={onContextMenu}
+      onClick={disabled ? undefined : onClick}
+      title={title}
+      onPointerDown={disabled ? undefined : onPointerDown}
+      onPointerUp={disabled ? undefined : onPointerUp}
+      onPointerLeave={disabled ? undefined : onPointerLeave}
+    >
       {isLoading ? <div className="invisible">{children}</div> : children}
       {isLoading && (
         <div className="absolute top-0 right-0 flex justify-center items-center h-full w-full p-2">

--- a/src/server/routers/spotify.ts
+++ b/src/server/routers/spotify.ts
@@ -3,6 +3,23 @@ import { SpotifyApi } from "../spotify-interface/spotify-api";
 import { createRouter, publicProcedure } from "../trpc";
 
 export const spotifyRouter = createRouter({
+  getPlaylistTracks: publicProcedure
+    .input(
+      z.object({
+        playlistId: z.string(),
+        cursor: z.number().int().min(0).optional(),
+        pageSize: z.number().int().min(1).optional(),
+      })
+    )
+    .query(async ({ input }) => {
+      const page = input.cursor ?? 0;
+      const result = await SpotifyApi.getPlaylistTracks(input.playlistId, page, input.pageSize);
+      return {
+        items: result.items,
+        total: result.total,
+        nextCursor: result.nextCursor,
+      };
+    }),
   getPlaylist: publicProcedure
     .input(
       z.object({

--- a/src/server/spotify-interface/spotify-api.ts
+++ b/src/server/spotify-interface/spotify-api.ts
@@ -57,6 +57,23 @@ export namespace SpotifyApi {
     };
   }
 
+  export async function getPlaylistTracks(
+    playlistId: string,
+    page: number = 0,
+    pageSize: number = PAGESIZE
+  ): Promise<{ items: Track[]; total: number; nextCursor?: number }> {
+    const offset = page * pageSize;
+    const data = await spotifyFetch(
+      `https://api.spotify.com/v1/playlists/${playlistId}/tracks?limit=${pageSize}&offset=${offset}`
+    );
+    const items = data.items.map(mapSpotifyTrack);
+    return {
+      items,
+      total: data.total,
+      nextCursor: offset + pageSize < data.total ? page + 1 : undefined,
+    };
+  }
+
   export async function getPlaylist(playlistId: string): Promise<IndividualPlaylist> {
     let playlistPayload = await spotifyFetch(
       `https://api.spotify.com/v1/playlists/${playlistId}?fields=name,images,owner,description,tracks(total,items(track.name, track.artists(name), track.uri),limit,href,next)`


### PR DESCRIPTION
feat: lazy-load playlist tracks on homepage

Open a playlist on the homepage now fetches only the first 100 tracks via
a new paginated tRPC procedure (spotify.getPlaylistTracks). A "Load more"
button fetches the next page; holding it (long-press) loads every remaining
page at once. "Pull all tracks" first loads the full list then scrapes. The
full-playlist getPlaylist / getPlaylistLazy endpoints are unchanged for the
import and folder paths.