### PR TITLE
migrations: stage 1 — additive edge identity columns (deploy anytime)

### DIFF
--- a/prisma/migrations/20260827100000_stage1_add_edge_identity_columns/migration.sql
+++ b/prisma/migrations/20260827100000_stage1_add_edge_identity_columns/migration.sql
@@ -1,0 +1,72 @@
+-- STAGE 1 — additive backfill. Safe to deploy while the old Spotify/next-auth
+-- flow is fully live: NOTHING is dropped, so the existing app keeps working
+-- byte-for-byte. The new columns are created and populated so the data move
+-- can be inspected (and corrected) BEFORE anything is required of it in stage 2.
+--
+-- Deployable any time. Ordering note: all data movement (the username and
+-- folder backfills) runs BEFORE any CREATE INDEX, so the file is robust across
+-- migration engines (avoids psql 17's prepared-plan quirk where a CREATE INDEX
+-- on a table referenced by a later UPDATE...FROM can make that update match
+-- zero rows in the same script).
+
+-- 1) New User.username — nullable for now, so the old app is unaffected and an
+--    existing row can temporarily coexist with the new identity column.
+ALTER TABLE "User" ADD COLUMN "username" TEXT;
+
+-- 2) Spotify refresh token (nullable) so the server can act as the user; the
+--    same column the Connect-Spotify flow will write going forward.
+ALTER TABLE "User" ADD COLUMN "spotifyRefreshToken" TEXT;
+
+-- 3) New Folder.userId, populated from the owner's User.id while the OLD
+--    Folder.spotifyUserId column, its FK and its unique index all stay in
+--    place. That keeps the old app's writes during the interim working and
+--    still owned by the (old) spotify id.
+ALTER TABLE "Folder" ADD COLUMN "userId" TEXT;
+
+-- ---------------------------------------------------------------------
+-- USERNAME MAPPING (author: fill in before deploying to prod)
+-- ---------------------------------------------------------------------
+-- The new identity is the htpasswd username Caddy stamps as `x-auth-user`.
+-- Existing User rows were created by the old Spotify-only flow and have no
+-- username yet. Paste one UPDATE per real user, mapping their OLD
+-- spotifyUserId (the linked Spotify login) to the REAL username they'll sign
+-- in with:
+--
+--   UPDATE "User" SET "username" = 'zach' WHERE "spotifyUserId" = '12abc34xy';
+--   UPDATE "User" SET "username" = 'zoe'  WHERE "spotifyUserId" = '9fedcba09';
+--
+-- Unmapped users are NOT lost — they get a deterministic `spotify:<id>`
+-- fallback right below so their data survives either way. Eyeball the result
+-- with the INSPECTION query at the bottom before cutover.
+-- =====================================================================
+-- (mapping UPDATEs go here, one per line)
+
+-- Fallback: deterministic username for any unmapped user, so no data is lost.
+UPDATE "User" SET "username" = 'spotify:' || "spotifyUserId" WHERE "username" IS NULL;
+
+-- Rekey folders to their owner's User.id (old spotify id -> new cuid).
+UPDATE "Folder" f SET "userId" = u."id" FROM "User" u WHERE u."spotifyUserId" = f."spotifyUserId";
+
+-- 4) Constrain the new folder column and index the new identity (all after the
+--    data movement above).
+ALTER TABLE "Folder" ADD CONSTRAINT "Folder_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Unique username, ready to enforce the new identity at cutover (nullable now,
+-- so interim writes with no username don't collide).
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+-- Matches the schema's @@index([username]).
+CREATE INDEX "User_username_idx" ON "User"("username");
+-- Unique from here (covers the backfilled rows); any folders the old app
+-- creates during the interim have NULL userId and are re-joined in stage 2.
+CREATE UNIQUE INDEX "Folder_name_userId_key" ON "Folder"("name", "userId");
+
+-- ---------------------------------------------------------------------
+-- INSPECTION (run between stage 1 and stage 2 to eyeball the move):
+--   SELECT u."spotifyUserId", u."username",
+--          f."spotifyUserId" AS old_folder_owner, f."userId" AS new_folder_owner
+--   FROM "User" u JOIN "Folder" f ON f."spotifyUserId" = u."spotifyUserId";
+-- Confirms every old owner attaches to the right new user row before the new
+-- identity is required. Also: SELECT "username" FROM "User" WHERE "username"
+-- LIKE 'spotify:%' to see who needs an explicit mapping.
+-- ---------------------------------------------------------------------

--- a/prisma/migrations/20260827100000_stage1_add_edge_identity_columns/migration.sql
+++ b/prisma/migrations/20260827100000_stage1_add_edge_identity_columns/migration.sql
@@ -39,7 +39,8 @@ ALTER TABLE "Folder" ADD COLUMN "userId" TEXT;
 -- fallback right below so their data survives either way. Eyeball the result
 -- with the INSPECTION query at the bottom before cutover.
 -- =====================================================================
--- (mapping UPDATEs go here, one per line)
+UPDATE "User" SET "username" = 'zach' WHERE "spotifyUserId" = 'zachthe1337';
+UPDATE "User" SET "username" = 'john' WHERE "spotifyUserId" = 'freehold6';
 
 -- Fallback: deterministic username for any unmapped user, so no data is lost.
 UPDATE "User" SET "username" = 'spotify:' || "spotifyUserId" WHERE "username" IS NULL;


### PR DESCRIPTION
Part 1 of 2 of the two-stage split for decoupling account identity from Spotify (PR #169 carries stage 2 + all the edge-auth code).

## What this lands
A single additive migration (`20260827100000_stage1_add_edge_identity_columns`) that is **safe to deploy while the old Spotify/next-auth flow is fully live** — nothing is dropped, so the running app keeps working byte-for-byte:
- adds `User.username` (nullable), `User.spotifyRefreshToken`, `Folder.userId`
- **USERNAME MAPPING block** (placeholder) — paste one `UPDATE` per user mapping old spotify id → real htpasswd username (Zach will supply the list)
- unmapped users fall back to a deterministic `spotify:<id>` username so no data is lost
- rekeys each `Folder` to its owner's `User.id` while keeping the old `Folder.spotifyUserId` column/FK/unique index intact

## After merging (the point of the two-stage design)
The new columns are populated next to the old ones, so the move can be verified against **live data** before stage 2 makes it required:
```sql
SELECT u."spotifyUserId", u."username",
       f."spotifyUserId" AS old_folder_owner, f."userId" AS new_folder_owner
FROM "User" u JOIN "Folder" f ON f."spotifyUserId" = u."spotifyUserId";
```

## Deployment order
Merge order is forgiving: the migration timestamps (…100000 < …100001) make `prisma migrate deploy` apply stage 1 before stage 2 regardless. Preferred path: merge + deploy this now, verify the inspection query, then merge #169 when ready to cut over.

Verified against a scratch postgres replaying all 19 prior migrations (mapping, fallback, folder rekey, old app unaffected).