### PR TITLE
Paginate playlist panel at 50 tracks per page

### DIFF
--- a/src/components/home/playlistpanel.tsx
+++ b/src/components/home/playlistpanel.tsx
@@ -8,7 +8,7 @@ import BasePanel from "../shared/basepanel";
 import PlainButton from "../shared/plainbutton";
 import PanelMenu from "./panelmenu";
 
-const TRACKS_PAGE_SIZE = 100;
+const TRACKS_PAGE_SIZE = 50;
 const LONG_PRESS_MS = 600;
 
 export default function PlaylistPanel({ playlist }: { playlist: Playlist }) {


### PR DESCRIPTION
## What

Tracks in the playlist panel now render **50 per page** instead of 100 (`TRACKS_PAGE_SIZE` in `src/components/home/playlistpanel.tsx`).

The panel was already paginated via the `getPlaylistTracks` infinite query (lazy-loaded since #165-ish / `7fddf34`), with the **Load more** button as the final item — this PR just drops the page size to 50 as requested.

## Behaviour (unchanged mechanics)

- Panel opens showing the first 50 tracks
- **Load more** (final item) appends the next 50 via `fetchNextPage()`; long-press still loads everything (existing "Pull all" helper behaviour)
- Server passes `pageSize` straight to Spotify's API (`limit=50&offset=…`), so a 500-item playlist is 10 requests of 50 rather than 5 of 100

## Checks

- `tsc --noEmit` ✅ (in devshell)
- `pnpm lint` ❌ **pre-existing**: `next lint` is broken on `main` — Next 16 dropped it and the repo's `.eslintrc.json` is the legacy format eslint 9 rejects. Not touched here; open to do separately if wanted.

## Notes

Your local checkout in `~/projects/penultimate-guitar` looked un-paginated, but `main` has since landed `7fddf34 feat: lazy-load playlist tracks on homepage` — the worktree was branched fresh from `origin/main`, which is the state this PR is based on.