### PR TITLE
fix: /profile crash (hooks-order) + hide Playlists without working Spotify link

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,6 +20,11 @@ import Playlists from "@/components/home/playlists";
 const Page: NextPageWithLayout = () => {
   const { data: recentTabs } = trpc.tab.getRecentTabs.useQuery(10);
   const { user } = useUser();
+  // Only surface Playlists to users with a *working* Spotify link (a persisted
+  // refresh token). A leftover spotifyUserId with no token — e.g. pre-migration
+  // accounts — would otherwise render the panel and error every load.
+  const { data: account } = trpc.user.me.useQuery(undefined, { enabled: !!user });
+  const spotifyLinked = !!account?.spotifyLinked;
 
   const { searchText } = useSearchStore();
   const { mode } = useConfigStore();
@@ -62,7 +67,7 @@ const Page: NextPageWithLayout = () => {
                 <SavedTabs />
               </div>
 
-              {user && (
+              {user && spotifyLinked && (
                 <div className="min-w-80 flex-1">
                   <Playlists />
                 </div>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -28,6 +28,16 @@ export default function Profile() {
   // Whether this user has a linked Spotify account (drives the connect prompt).
   const account = trpc.user.me.useQuery(undefined, { enabled: !!user });
 
+  // Unlink the Spotify account. Declared up top alongside every other hook:
+  // React enforces a stable number of hooks per render, and this must stay
+  // unconditional even though the signed-out path returns early below (an
+  // early-return before this hook previously caused React error #310 on the
+  // authed render — the signed-out shell rendered 9 hooks, then the signed-in
+  // render tried for 10).
+  const disconnectSpotify = trpc.user.disconnectSpotify.useMutation({
+    onSuccess: () => account.refetch(),
+  });
+
   const {
     data,
     isFetching,
@@ -39,7 +49,7 @@ export default function Profile() {
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       initialCursor: 1,
-      enabled: !!user && !!account.data?.spotifyUserId,
+      enabled: !!user && !!account.data?.spotifyLinked,
     }
   );
 
@@ -76,11 +86,7 @@ export default function Profile() {
     return <LoadingSpinner className="h-8" />;
   }
 
-  const linked = !!account.data?.spotifyUserId;
-
-  const disconnectSpotify = trpc.user.disconnectSpotify.useMutation({
-    onSuccess: () => account.refetch(),
-  });
+  const linked = !!account.data?.spotifyLinked;
 
   // Edge logout. Identity is HTTP Basic auth stamped by Caddy, so there is no
   // server session to destroy. Caddy accepts a reserved `guest` account (see

--- a/src/server/routers/user.ts
+++ b/src/server/routers/user.ts
@@ -5,9 +5,13 @@ import { authProcedure, createRouter } from "../trpc";
 
 export const userRouter = createRouter({
   // Current account's Spotify link state, for the Connect-Spotify affordance.
+  // `spotifyLinked` reflects a *working* link (refresh token persisted) — a
+  // leftover spotifyUserId with no token (e.g. pre-migration accounts) is NOT
+  // a usable link and should drive the Connect prompt, not playlist loading.
   me: authProcedure.query(async ({ ctx }) => ({
     username: ctx.account.username,
     spotifyUserId: ctx.account.spotifyUserId,
+    spotifyLinked: !!ctx.account.spotifyRefreshToken,
   })),
 
   // Unlink the Spotify account. Clears the linked spotify id and the stored


### PR DESCRIPTION
Two issues found after the edge-auth cutover, both reproduced in headless Chromium through a local proxy that injects Basic auth (so I had a real authenticated browser session):\n\n## 1. Direct /profile navigation crashed (React error #310)\n```\nError: Minified React error #310  (rendered more hooks than during the previous render)\nA client-side exception has occurred\nApplication error\n```\n`profile.tsx` declared the `disconnectSpotify` `useMutation` **after** the `if (!user) return <LoadingSpinner/>` early return. On first paint the signed-out shell rendered 9 hooks; once `whoami` resolved, the authed render tried for 10 → hooks mismatch → hard crash. Fix: hoist the mutation above the early return so hooks are unconditional.\n\n## 2. Playlists panel showed without a working Spotify link\n\n`user.me` only exposed `spotifyUserId`. Pre-migration accounts (zach/john) carry a `spotifyUserId` but **no refresh token**, so the UI treated them as 'Spotify connected', rendered the panel, and `getPlaylists` errored (412) on every load — a refetch loop on the homepage.\n\nFix: `user.me` now returns `spotifyLinked: !!spotifyRefreshToken` (a *working* link). Gated the homepage Playlists panel and the profile page's playlist query on it; both now show the Connect-Spotify prompt instead.\n\nVerified: /profile renders 'signed in as john' + 'Connect your Spotify account' cleanly (no error). `tsc --noEmit` clean. Only 3 files changed.