### PR TITLE
perf: load playlists in parallel with the rest of the homepage

### DIFF
--- a/src/components/home/playlists.tsx
+++ b/src/components/home/playlists.tsx
@@ -2,19 +2,43 @@ import { trpc } from "@/utils/trpc";
 import { Load } from "../loadingspinner";
 import PlainButton from "../shared/plainbutton";
 import PlaylistPanel from "./playlistpanel";
+import SpotifyButton from "../buttons/spotifybutton";
+import { startConnectSpotify } from "@/utils/spotify";
 
 export default function Playlists() {
-  const { data, isLoading, isFetching, hasNextPage, fetchNextPage } = trpc.user.getPlaylists.useInfiniteQuery(
+  const { data, isLoading, isFetching, hasNextPage, fetchNextPage, error } = trpc.user.getPlaylists.useInfiniteQuery(
     {
       pageSize: 20,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       initialCursor: 1,
+      // No point retrying a missing Spotify link — the server refuses with
+      // PRECONDITION_FAILED until the user connects one.
+      retry: false,
     }
   );
 
   const playlists = data?.pages.flatMap((p) => p.items) ?? [];
+
+  // No linked Spotify account — the server refuses with PRECONDITION_FAILED.
+  // Surface the Connect affordance instead of an error (same as /profile).
+  if (error?.data?.code === "PRECONDITION_FAILED") {
+    return (
+      <div>
+        <div className="flex justify-between items-center pt-4">
+          <h1 className="text-left text-xl">Playlists</h1>
+          <div className="text-sm text-red-700">ALPHA</div>
+        </div>
+        <div className="flex flex-col gap-2 mt-2">
+          <p>Connect Spotify to list and import your own playlists.</p>
+          <SpotifyButton onClick={() => startConnectSpotify().catch(console.error)}>
+            Connect your Spotify account
+          </SpotifyButton>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,11 +20,11 @@ import Playlists from "@/components/home/playlists";
 const Page: NextPageWithLayout = () => {
   const { data: recentTabs } = trpc.tab.getRecentTabs.useQuery(10);
   const { user } = useUser();
-  // Only surface Playlists to users with a *working* Spotify link (a persisted
-  // refresh token). A leftover spotifyUserId with no token — e.g. pre-migration
-  // accounts — would otherwise render the panel and error every load.
-  const { data: account } = trpc.user.me.useQuery(undefined, { enabled: !!user });
-  const spotifyLinked = !!account?.spotifyLinked;
+  // Mount Playlists for any signed-in user and let the panel itself handle the
+  // no-Spotify-link case (the server refuses with PRECONDITION_FAILED and the
+  // panel shows a Connect prompt). Firing the query straight away — instead of
+  // waiting on a separate `me` round trip to learn spotifyLinked — is what keeps
+  // playlists from loading noticeably later than everything else on the page.
 
   const { searchText } = useSearchStore();
   const { mode } = useConfigStore();
@@ -67,7 +67,7 @@ const Page: NextPageWithLayout = () => {
                 <SavedTabs />
               </div>
 
-              {user && spotifyLinked && (
+              {user && (
                 <div className="min-w-80 flex-1">
                   <Playlists />
                 </div>


### PR DESCRIPTION
## What

The homepage serialized `whoami → user.me → getPlaylists`: the Playlists panel only mounted after a separate `me` round trip confirmed `spotifyLinked`, so playlists — already the slowest query on the page (it hits the Spotify API) — started last.

This mounts the panel for any signed-in user and lets the server's existing `PRECONDITION_FAILED` (no linked Spotify account) drive a Connect prompt inside the panel, same as /profile.

## Why

- Removes the `me` round trip from the homepage entirely
- The Spotify call now starts as soon as `whoami` resolves, in parallel with everything else
- `retry: false` so unlinked users don't get 3 background retries per page load

## UX note

Unlinked users now see a "Connect your Spotify account" prompt in the Playlists panel instead of the panel being hidden (the #174 behavior). The erroring-every-load problem #174 fixed is still solved — the error is caught and rendered as the prompt.

## Verification

`tsc --noEmit` clean.